### PR TITLE
plugin script seems to be bash, not sh

### DIFF
--- a/plugins/kernel_version_compare
+++ b/plugins/kernel_version_compare
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Author: Jens Giessmann jg@handcode.de
 # Date: 2017-07-14


### PR DESCRIPTION
```
# sh plugins/kernel_version_compare
plugins/kernel_version_compare: 14: [: Linux: unexpected operator
plugins/kernel_version_compare: 21: [: GNU/Linux: unexpected operator
```
```
# bash plugins/kernel_version_compare
<<<kernel_version_compare>>>
Linux 4.9.110-3+deb9u5 4.9.110-3+deb9u6
```